### PR TITLE
Fix runtime errors new to Python 3.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
   - pip --version
 
   # Install tox from the wheelhouse
-  - pip install --use-wheel --no-index --find-links=requirements/wheelhouse tox wheel codecov
+  - pip install --no-index --find-links=requirements/wheelhouse tox wheel codecov
 
 # Not a C# project, build stuff at the test step instead.
 build: false  

--- a/blazeutils/containers.py
+++ b/blazeutils/containers.py
@@ -69,11 +69,12 @@ class HTMLAttributes(LazyDict):
 
     def _clean_key(self, key):
         if key.endswith('_'):
-            key = key[:-1]
+            return key[:-1]
         return key
 
     def _clean_keys(self):
-        for key in self.keys():
+        old_keys = list(self.keys())
+        for key in old_keys:
             new_key = self._clean_key(key)
             if new_key != key:
                 # have to use LazyDict b/c our __getitem__ will clean `key` and

--- a/blazeutils/strings.py
+++ b/blazeutils/strings.py
@@ -133,7 +133,8 @@ def randnumerics(n=12):
 
 
 def randhash():
-    random_str = six.text_type(random.random()) + six.text_type(time.clock())
+    random_str = six.text_type(random.random()) + six.text_type(
+        time.clock() if six.PY2 else time.process_time())
     return hashlib.md5(random_str.encode('utf-8')).hexdigest()
 
 

--- a/docker-entry
+++ b/docker-entry
@@ -19,7 +19,7 @@ ls -la
 # b/c it gives me control over what version of tox I'm using without having to rebuild the
 # docker image.
 python3.5 -m pip install --upgrade --force-reinstall \
-    --quiet --use-wheel --no-index --find-links=requirements/wheelhouse tox
+    --quiet --no-index --find-links=requirements/wheelhouse tox
 
 # run the tests using our target python version
 python3.5 -m tox


### PR DESCRIPTION
- Don't change dict while iterating
- Use time.process_time instead of time.clock for Python 3

Fixes #11