### PR TITLE
Add openpyxl support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+indent_style = space
+# isort
+force_sort_within_sections = true

--- a/blazeutils/spreadsheets.py
+++ b/blazeutils/spreadsheets.py
@@ -8,6 +8,11 @@ from random import randint
 import os.path as osp
 
 try:
+    import openpyxl
+except ImportError:
+    openpyxl = None
+
+try:
     import xlrd
 except ImportError:
     xlrd = None
@@ -34,11 +39,6 @@ def _xlrd_required():
 def _xlwt_required():
     if xlwt is None:
         raise ImportError('xlwt library is required to use this function or class')
-
-
-def _xlsx_required():
-    if xlsxwriter is None:
-        raise ImportError('xlsxwriter library is required to use this function or class')
 
 
 def http_headers(filename, randomize=True):
@@ -87,7 +87,7 @@ def xlsx_to_strio(xlsx_wb):
 
 def xlsx_to_reader(xlsx_wb):
     """
-        convert xlwt Workbook instance to an xlrd instance for reading
+        convert xlsxwriter Workbook instance to an xlrd instance for reading
     """
     fh = xlsx_to_strio(xlsx_wb)
     return xlrd.open_workbook(file_contents=fh.read())
@@ -223,7 +223,36 @@ class Writer(object):
         return f
 
 
-class WriterX(object):
+class _OpenpyxlWriter:
+    def __init__(self, ws):
+        self.set_sheet(ws)
+
+    def set_sheet(self, ws):
+        self.ws = ws
+        # Openpyxl uses 1-based indexing for cells
+        self.rownum = 1
+        self.colnum = 1
+
+    def awrite(self, data, style=None, nextrow=False):
+        cell = self.ws.cell(column=self.colnum, row=self.rownum, value=data)
+        if style:
+            cell.style = style
+        self.colnum += 1
+        if nextrow:
+            self.nextrow()
+
+    def mwrite(self, *colvals, style=None, nextrow=False):
+        for val in colvals:
+            self.awrite(val, style)
+        if nextrow:
+            self.nextrow()
+
+    def nextrow(self):
+        self.rownum += 1
+        self.colnum = 1
+
+
+class _XlsxwriterWriter:
 
     def __init__(self, ws):
         self.set_sheet(ws)
@@ -239,9 +268,7 @@ class WriterX(object):
         if nextrow:
             self.nextrow()
 
-    def mwrite(self, *colvals, **kwargs):
-        style = kwargs.pop('style', None)
-        nextrow = kwargs.pop('nextrow', False)
+    def mwrite(self, *colvals, style=None, nextrow=False):
         for val in colvals:
             self.awrite(val, style)
         if nextrow:
@@ -252,6 +279,54 @@ class WriterX(object):
         self.colnum = 0
 
 
+class WriterX:
+    @property
+    def ws(self):
+        return self._writer.ws
+
+    @property
+    def rownum(self):
+        return self._writer.rownum
+
+    @rownum.setter
+    def rownum(self, value):
+        self._writer.rownum = value
+
+    @property
+    def colnum(self):
+        return self._writer.colnum
+
+    @colnum.setter
+    def colnum(self, value):
+        self._writer.colnum = value
+
+    def __init__(self, ws):
+        self._writer = None
+        if openpyxl:
+            from openpyxl.worksheet.worksheet import Worksheet
+            if isinstance(ws, Worksheet):
+                self._writer = _OpenpyxlWriter(ws)
+        if xlsxwriter:
+            from xlsxwriter.worksheet import Worksheet
+            if isinstance(ws, Worksheet):
+                self._writer = _XlsxwriterWriter(ws)
+
+        if not self._writer:
+            raise TypeError('worksheet type not supported')
+
+    def set_sheet(self, ws):
+        self._writer.set_sheet(ws)
+
+    def awrite(self, data, style=None, nextrow=False):
+        self._writer.awrite(data, style=style, nextrow=nextrow)
+
+    def mwrite(self, *colvals, style=None, nextrow=False):
+        self._writer.mwrite(*colvals, style=style, nextrow=nextrow)
+
+    def nextrow(self):
+        self._writer.nextrow()
+
+
 class XlwtHelper(Writer):
 
     @deprecate('XlwtHelper has been renamed to Writer')
@@ -259,25 +334,14 @@ class XlwtHelper(Writer):
         Writer.__init__(self, ws)
 
 
-class Reader(object):
-
+class _XlrdReader:
+    @deprecate('xlrd is no longer maintained, recommend switching to openpyxl')
     def __init__(self, xlrd_wb, sheetnum=0):
-        _xlrd_required()
         self.book = xlrd_wb
         self.sheetnum = sheetnum
         self.rownum = 0
         self.colnum = 0
         self.sheet = self.book.sheet_by_index(self.sheetnum)
-
-    @classmethod
-    def from_xlwt(cls, xlwt_wb):
-        wb = workbook_to_reader(xlwt_wb)
-        return cls(wb)
-
-    @classmethod
-    def from_xlsx(cls, xlsx_wb):
-        wb = xlsx_to_reader(xlsx_wb)
-        return cls(wb)
 
     def cell_value(self, is_date=False):
         try:
@@ -302,3 +366,93 @@ class Reader(object):
     def next_row(self):
         self.rownum += 1
         self.colnum = 0
+
+
+class _OpenpyxlReader:
+    def __init__(self, openpyxl_wb, sheetnum=0):
+        self.book = openpyxl_wb
+        self.sheetnum = sheetnum
+        # Openpyxl uses 1-based indexing for cells
+        self.rownum = 1
+        self.colnum = 1
+        self.sheet = self.book[self.book.sheetnames[sheetnum]]
+
+    def cell_value(self, is_date=False):
+        try:
+            return self.sheet.cell(self.rownum, self.colnum).value
+        finally:
+            self.colnum += 1
+
+    def cell_date(self):
+        # Openpyxl automatically converts to date or datetime
+        value = self.cell_value()
+        if isinstance(value, dt.datetime):
+            return value.date()
+        elif isinstance(value, dt.date):
+            return value
+        else:
+            raise TypeError(f'{value}: not a date')
+
+    def cell_datetime(self):
+        # Openpyxl automatically converts to date or datetime
+        value = self.cell_value()
+        if isinstance(value, dt.datetime):
+            return value
+        elif isinstance(value, dt.date):
+            return dt.datetime(value.year, value.month, value.day)
+        else:
+            raise ValueError(f'{value}: not a datetime')
+
+    def cell_decimal(self):
+        value = self.cell_value()
+        return Decimal(value)
+
+    def next_row(self):
+        self.rownum += 1
+        self.colnum = 1
+
+
+class Reader(object):
+    def __init__(self, workbook, sheetnum=0):
+        self._reader = None
+        if openpyxl:
+            from openpyxl.workbook import Workbook
+            if isinstance(workbook, Workbook):
+                self._reader = _OpenpyxlReader(workbook, sheetnum=sheetnum)
+        if xlrd:
+            if xlsxwriter:
+                from xlsxwriter import Workbook
+                if isinstance(workbook, Workbook):
+                    self._reader = _XlrdReader(workbook, sheetnum=sheetnum)
+            if xlwt:
+                from xlwt.Workbook import Workbook
+                if isinstance(workbook, Workbook):
+                    self._reader = _XlrdReader(workbook, sheetnum=sheetnum)
+
+        if not self._reader:
+            raise TypeError('workbook type not supported')
+
+    @classmethod
+    def from_xlwt(cls, xlwt_wb):
+        wb = workbook_to_reader(xlwt_wb)
+        return _XlrdReader(wb)
+
+    @classmethod
+    def from_xlsx(cls, xlsx_wb):
+        wb = xlsx_to_reader(xlsx_wb)
+        return _XlrdReader(wb)
+
+    def cell_value(self, is_date=False):
+        return self._reader.cell_value(is_date=is_date)
+
+    def cell_date(self):
+        return self._reader.cell_date()
+
+    def cell_datetime(self):
+        return self._reader.cell_datetime()
+
+    def cell_decimal(self):
+        return self._reader.cell_decimal()
+
+    def next_row(self):
+        self._reader.next_row()

--- a/blazeutils/tests/test_spreadsheets.py
+++ b/blazeutils/tests/test_spreadsheets.py
@@ -1,18 +1,27 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
+import datetime as dt
+import decimal
 
 import pytest
-import six
 
-from blazeutils.spreadsheets import workbook_to_reader, XlwtHelper, http_headers, xlsx_to_reader
+from blazeutils.spreadsheets import (
+    Reader,
+    WriterX,
+    XlwtHelper,
+    http_headers,
+    workbook_to_reader,
+    xlsx_to_reader,
+    xlsx_to_strio,
+)
 from blazeutils.testing import emits_deprecation
 
 
 class TestWorkbookToReader(object):
 
-    @pytest.mark.skipif(not six.PY2, reason="xlwt only works on Python 2")
     def test_xlwt_to_reader(self):
         import xlwt
+
         write_wb = xlwt.Workbook()
         ws = write_wb.add_sheet('Foo')
         ws.write(0, 0, 'bar')
@@ -26,6 +35,7 @@ class TestXlsxToReader(object):
 
     def test_xlsx_to_reader(self):
         import xlsxwriter
+
         write_wb = xlsxwriter.Workbook()
         ws = write_wb.add_worksheet('Foo')
         ws.write(0, 0, 'bar')
@@ -38,9 +48,335 @@ class TestXlsxToReader(object):
 class TestWriter(object):
 
     @emits_deprecation('XlwtHelper has been renamed to Writer')
-    @pytest.mark.skipif(not six.PY2, reason="xlwt only works on Python 2")
     def test_xlwt_helper_deprecation(self):
         XlwtHelper()
+
+
+class TestWriterX:
+    def test_unknown_type(self):
+        with pytest.raises(TypeError):
+            WriterX({'bad': 'format'})
+
+
+class TestOpenpyxlWriter:
+    def test_awrite(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        writer = WriterX(sheet)
+        writer.awrite('Pooh')
+        writer.awrite('Bar', nextrow=True)
+        writer.awrite('Baz')
+        assert sheet.cell(row=1, column=1).value == 'Pooh'
+        assert sheet.cell(row=1, column=2).value == 'Bar'
+        assert sheet.cell(row=2, column=1).value == 'Baz'
+
+    def test_awrite_style(self):
+        import openpyxl
+        from openpyxl.styles import Font, NamedStyle, PatternFill
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        writer = WriterX(sheet)
+        style = NamedStyle(name='test')
+        font = Font(bold=True, size=20, color='ff0000')
+        fill = PatternFill(start_color='ff0000ff', end_color='ff0000ff', fill_type='solid')
+        style.font = font
+        style.fill = fill
+        writer.awrite('Bar', style=style)
+        cell = sheet['A1']
+        assert cell.value == 'Bar'
+        assert cell.font == font
+        assert cell.fill == fill
+
+    def test_mwrite(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        writer = WriterX(sheet)
+        row1 = ['Pooh', 'Bar', 'Baz', 'ab', 'cd', 'ef']
+        row2 = ['gh', 'ij', 'kl']
+        writer.mwrite(*row1[:3])
+        writer.mwrite(*row1[3:], nextrow=True)
+        writer.mwrite(*row2)
+        for colnum in range(1, len(row1) + 1):
+            assert sheet.cell(row=1, column=colnum).value == row1[colnum-1]
+        for colnum in range(1, len(row2) + 1):
+            assert sheet.cell(row=2, column=colnum).value == row2[colnum-1]
+
+    def test_mwrite_style(self):
+        import openpyxl
+        from openpyxl.styles import Font, NamedStyle, PatternFill
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        writer = WriterX(sheet)
+        style = NamedStyle(name='test')
+        font = Font(bold=True, size=20, color='ff0000')
+        fill = PatternFill(start_color='ff0000ff', end_color='ff0000ff', fill_type='solid')
+        style.font = font
+        style.fill = fill
+        row = ['Pooh', 'Bar', 'Baz']
+        writer.mwrite(*row, style=style)
+        for colnum in range(1, len(row) + 1):
+            cell = sheet.cell(row=1, column=colnum)
+            assert cell.value == row[colnum-1]
+            assert cell.font == font
+            assert cell.fill == fill
+
+
+class TestXlsxwriterWriter:
+    def test_awrite(self):
+        import openpyxl
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        writer = WriterX(sheet)
+        writer.awrite('Pooh')
+        writer.awrite('Bar', nextrow=True)
+        writer.awrite('Baz')
+
+        read_workbook = openpyxl.load_workbook(xlsx_to_strio(workbook))
+        read_sheet = read_workbook[read_workbook.sheetnames[0]]
+        assert read_sheet['A1'].value == 'Pooh'
+        assert read_sheet['B1'].value == 'Bar'
+        assert read_sheet['A2'].value == 'Baz'
+
+    def test_awrite_style(self):
+        import openpyxl
+        import xlsxwriter
+        from blazeutils.spreadsheets import WriterX
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        writer = WriterX(sheet)
+        format = workbook.add_format({
+            'bold': True, 'font_color': 'red', 'font_size': 20, 'bg_color': 'blue',
+        })
+        writer.awrite('Bar', style=format)
+
+        read_workbook = openpyxl.load_workbook(xlsx_to_strio(workbook))
+        read_sheet = read_workbook[read_workbook.sheetnames[0]]
+        cell = read_sheet['A1']
+        assert cell.value == 'Bar'
+        assert cell.font.color.value == 'FFFF0000'
+        assert cell.font.bold
+        assert cell.font.size == 20
+        assert cell.fill.fgColor.value == 'FF0000FF'
+
+    def test_mwrite(self):
+        import openpyxl
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        writer = WriterX(sheet)
+        row1 = ['Pooh', 'Bar', 'Baz', 'ab', 'cd', 'ef']
+        row2 = ['gh', 'ij', 'kl']
+        writer.mwrite(*row1[:3])
+        writer.mwrite(*row1[3:], nextrow=True)
+        writer.mwrite(*row2)
+
+        read_workbook = openpyxl.load_workbook(xlsx_to_strio(workbook))
+        read_sheet = read_workbook[read_workbook.sheetnames[0]]
+        for colnum in range(1, len(row1) + 1):
+            assert read_sheet.cell(row=1, column=colnum).value == row1[colnum-1]
+        for colnum in range(1, len(row2) + 1):
+            assert read_sheet.cell(row=2, column=colnum).value == row2[colnum-1]
+
+    def test_mwrite_style(self):
+        import openpyxl
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        writer = WriterX(sheet)
+        format = workbook.add_format({
+            'bold': True, 'font_color': 'red', 'font_size': 20, 'bg_color': 'blue',
+        })
+        writer = WriterX(sheet)
+        row = ['Pooh', 'Bar', 'Baz']
+        writer.mwrite(*row, style=format)
+
+        read_workbook = openpyxl.load_workbook(xlsx_to_strio(workbook))
+        read_sheet = read_workbook[read_workbook.sheetnames[0]]
+        for colnum in range(1, len(row) + 1):
+            cell = read_sheet.cell(row=1, column=colnum)
+            assert cell.value == row[colnum-1]
+            assert cell.font.color.value == 'FFFF0000'
+            assert cell.font.bold
+            assert cell.font.size == 20
+            assert cell.fill.fgColor.value == 'FF0000FF'
+
+
+class TestReader:
+    def test_unknown_type(self):
+        with pytest.raises(TypeError):
+            Reader({'bad': 'format'})
+
+    def test_from_xlwt(self):
+        import xlwt
+
+        write_wb = xlwt.Workbook()
+        ws = write_wb.add_sheet('Foo')
+        ws.write(0, 0, 'bar')
+
+        reader = Reader.from_xlwt(write_wb)
+        assert reader.cell_value() == 'bar'
+
+    def test_from_xlsx(self):
+        import xlsxwriter
+
+        write_wb = xlsxwriter.Workbook()
+        ws = write_wb.add_worksheet('Foo')
+        ws.write('A1', 'bar')
+
+        reader = Reader.from_xlsx(write_wb)
+        assert reader.cell_value() == 'bar'
+
+
+class TestReaderOpenpyxl:
+    def test_cell_value(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        sheet['A1'] = 'Pooh'
+        sheet['B1'] = 'Bar'
+        reader = Reader(workbook)
+        assert reader.cell_value() == 'Pooh'
+        assert reader.cell_value() == 'Bar'
+        assert reader.cell_value() is None
+
+    def test_cell_date(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        sheet['A1'] = dt.date(2020, 1, 1)
+        sheet['B1'] = dt.datetime(2019, 12, 31, 3, 5)
+        sheet['C1'] = 'Bla'
+        reader = Reader(workbook)
+        assert reader.cell_date() == dt.date(2020, 1, 1)
+        assert reader.cell_date() == dt.date(2019, 12, 31)
+        with pytest.raises(TypeError) as e:
+            reader.cell_date()
+            assert str(e) == 'Bla: not a date'
+
+    def test_cell_datetime(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        sheet['A1'] = dt.date(2020, 1, 1)
+        sheet['B1'] = dt.datetime(2019, 12, 31, 3, 5)
+        sheet['C1'] = 'Bla'
+        reader = Reader(workbook)
+        assert reader.cell_datetime() == dt.datetime(2020, 1, 1, 0, 0)
+        assert reader.cell_datetime() == dt.datetime(2019, 12, 31, 3, 5)
+        with pytest.raises(TypeError) as e:
+            reader.cell_date()
+            assert str(e) == 'Bla: not a datetime'
+
+    def test_cell_decimal(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        sheet['A1'] = '1234.56'
+        sheet['B1'] = 'Bla'
+        reader = Reader(workbook)
+        assert reader.cell_decimal() == decimal.Decimal('1234.56')
+        with pytest.raises(decimal.InvalidOperation):
+            reader.cell_decimal()
+        with pytest.raises(TypeError):
+            reader.cell_decimal()
+
+    def test_next_row(self):
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook[workbook.sheetnames[0]]
+        sheet['A1'] = 'A1-text'
+        sheet['A2'] = 'A2-text'
+        sheet['B2'] = 'B2-text'
+        reader = Reader(workbook)
+        assert reader.cell_value() == 'A1-text'
+        reader.next_row()
+        assert reader.cell_value() == 'A2-text'
+        assert reader.cell_value() == 'B2-text'
+
+
+class TestReaderXlrd:
+    def test_cell_value(self):
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        sheet.write(0, 0, 'Pooh')
+        sheet.write(0, 1, 'Bar')
+        reader = Reader.from_xlsx(workbook)
+        assert reader.cell_value() == 'Pooh'
+        assert reader.cell_value() == 'Bar'
+
+    def test_cell_date(self):
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        sheet.write_datetime('A1', dt.date(2020, 1, 1))
+        sheet.write_datetime('B1', dt.datetime(2019, 12, 31, 3, 5))
+        sheet.write('C1', 'Bla')
+        reader = Reader.from_xlsx(workbook)
+        assert reader.cell_date() == dt.date(2020, 1, 1)
+        assert reader.cell_date() == dt.date(2019, 12, 31)
+        with pytest.raises(TypeError) as e:
+            reader.cell_date()
+            assert str(e) == 'Bla: not a date'
+
+    def test_cell_datetime(self):
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        sheet.write_datetime('A1', dt.date(2020, 1, 1))
+        sheet.write_datetime('B1', dt.datetime(2019, 12, 31, 3, 5))
+        sheet.write('C1', 'Bla')
+        reader = Reader.from_xlsx(workbook)
+        assert reader.cell_datetime() == dt.datetime(2020, 1, 1, 0, 0)
+        assert reader.cell_datetime() == dt.datetime(2019, 12, 31, 3, 5)
+        with pytest.raises(TypeError) as e:
+            reader.cell_date()
+            assert str(e) == 'Bla: not a datetime'
+
+    def test_cell_decimal(self):
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        sheet.write('A1', '1234.56')
+        sheet.write('B1', 'Bla')
+        reader = Reader.from_xlsx(workbook)
+        assert reader.cell_decimal() == decimal.Decimal('1234.56')
+        with pytest.raises(decimal.InvalidOperation):
+            reader.cell_decimal()
+
+    def test_next_row(self):
+        import xlsxwriter
+
+        workbook = xlsxwriter.Workbook()
+        sheet = workbook.add_worksheet('Foo')
+        sheet.write('A1', 'A1-text')
+        sheet.write('A2', 'A2-text')
+        sheet.write('B2', 'B2-text')
+        reader = Reader.from_xlsx(workbook)
+        assert reader.cell_value() == 'A1-text'
+        reader.next_row()
+        assert reader.cell_value() == 'A2-text'
+        assert reader.cell_value() == 'B2-text'
 
 
 class TestHttpHeaders(object):

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,5 @@
 -r testing.txt
 
+flake8
 restview
 wheel

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,6 +3,7 @@
 codecov
 docutils
 mock
+openpyxl
 pytest
 pytest-cov
 sqlalchemy


### PR DESCRIPTION
- Reader and WriterX choose an implementation based on workbook
  or worksheet type

Fixes blazelibs/blazeutils#18

~TODO:~

- ~[x] Add test for unsupported workbook type~